### PR TITLE
New crossword layout

### DIFF
--- a/src/Crossword/CrosswordGenerator.java
+++ b/src/Crossword/CrosswordGenerator.java
@@ -75,13 +75,13 @@ public class CrosswordGenerator{
 							gridInit[j][i] = Integer.toString(problemNumber);
 							entries.get(current).setClueNumber(problemNumber);	//add clue number to entry
 							if(entries.get(current).isAcross()){
-								entries.get(current).definition = Integer.toString(problemNumber) + ". " + entries.get(current).getDefinition();
+								entries.get(current).definition = Integer.toString(problemNumber) + ".  " + entries.get(current).getDefinition();
 								acrossClues.add(entries.get(current).definition);
 								entries.get(current).setEntryAcross(entryAcross);
 								entryAcross++;
 							}
 							else{
-								entries.get(current).definition = Integer.toString(problemNumber) + ". " + entries.get(current).getDefinition();
+								entries.get(current).definition = Integer.toString(problemNumber) + ".  " + entries.get(current).getDefinition();
 								downClues.add(entries.get(current).definition);
 								entries.get(current).setEntryDown(entryDown);
 								entryDown++;

--- a/src/Crossword/DrawCrossword.java
+++ b/src/Crossword/DrawCrossword.java
@@ -559,6 +559,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 					firsteverclick=false;
 				}
 
+				makeAllCluesWhite();
 					
 						
 				
@@ -568,6 +569,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 						
 						
 						if (e.getSource() == boxes[row][col]) {
+							makeAllCluesWhite();
 							
 							if (e.getKeyCode() == KeyEvent.VK_UP) {			
 								// get rid of all previous highlighting
@@ -584,11 +586,12 @@ public class DrawCrossword extends JComponent implements ActionListener {
 										boxes[ (newstart-i) ][col].requestFocus();
 										// highlight any words that *start* from this square
 										highlightWord( newstart-i, col);
-										colorAppropriateClue();
+//										colorAppropriateClue();
 										break;
 									}
 								}	
-								
+								makeAllCluesWhite();
+								colorAppropriateClue();
 							}
 							if (e.getKeyCode() == KeyEvent.VK_DOWN) {						
 								makeAllWhite();
@@ -602,7 +605,9 @@ public class DrawCrossword extends JComponent implements ActionListener {
 										highlightWord(newstart+i,col);
 										break;
 									}						
-								}																							
+								}	
+								makeAllCluesWhite();
+								colorAppropriateClue();
 							}
 							if (e.getKeyCode() == KeyEvent.VK_RIGHT) {
 								makeAllWhite();
@@ -616,7 +621,9 @@ public class DrawCrossword extends JComponent implements ActionListener {
 										highlightWord(row, newstart+i);
 										break;
 									}
-								}								
+								}		
+								makeAllCluesWhite();
+								colorAppropriateClue();
 							}
 							if (e.getKeyCode() == KeyEvent.VK_LEFT) {
 								makeAllWhite();
@@ -630,7 +637,9 @@ public class DrawCrossword extends JComponent implements ActionListener {
 										highlightWord(row,newstart-i);
 										break;
 									}
-								}															
+								}	
+								makeAllCluesWhite();
+								colorAppropriateClue();
 							}
 							
 							
@@ -706,7 +715,11 @@ public class DrawCrossword extends JComponent implements ActionListener {
 										}
 									}									
 								}
-																
+									
+								
+								makeAllCluesWhite();
+								colorAppropriateClue();
+								
 							}
 							
 												
@@ -725,6 +738,13 @@ public class DrawCrossword extends JComponent implements ActionListener {
 								
 					
 							}
+							
+							
+//							makeAllCluesWhite();
+//							colorAppropriateClue();
+
+							
+							
 						}
 					}
 
@@ -1229,6 +1249,8 @@ public class DrawCrossword extends JComponent implements ActionListener {
 	
 	public void colorAppropriateClue(){
 		
+		makeAllCluesWhite();
+		
 		// get a coloured square
 		int coloredX=0;  int coloredY=0;
 		for( int abc=0; abc<x-2; abc++ ){
@@ -1258,11 +1280,12 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		// get clue number 
 		int cn_h = -1;
 		
-		if( dd.equals("across") ){
+		if( dd.equalsIgnoreCase("across") ){
 			System.out.println("across");
 			for( int gg=0; gg<x-2; gg++ ){
 				
-				if( !clueNumbers[coloredY][coloredX-gg].getText().equals("") ){
+				if( (!clueNumbers[coloredY][coloredX-gg].getText().equals("") && coloredX-gg==0)
+						|| (!clueNumbers[coloredY][coloredX-gg].getText().equals("") && !boxes[coloredY][coloredX-gg-1].isEnabled() )  ){
 					
 					cn_h = Integer.parseInt( clueNumbers[coloredY][coloredX-gg].getText()  );
 					
@@ -1285,18 +1308,40 @@ public class DrawCrossword extends JComponent implements ActionListener {
 					}
 					break;										
 				}
-
-				
 			}
 		}
 		else if( dd.equalsIgnoreCase("down") ){
-			
+						
+			for( int gg=0; gg<y-2; gg++ ){
+				
+				if( (!clueNumbers[coloredY-gg][coloredX].getText().equals("")  && coloredY-gg==0 )     ||
+					( !clueNumbers[coloredY-gg][coloredX].getText().equals("")  &&  !boxes[coloredY-gg-1][coloredX].isEnabled()   )    ){
+					
+					cn_h = Integer.parseInt( clueNumbers[coloredY-gg][coloredX].getText()  );
+										
+					makeAllCluesWhite();
+					
+					// highlight appropriate clue
+					for( JTextArea cl : cluesDwn ){		
+						
+						if( cl.getText().contains(".") ){
+							String c_n_string = ""+cl.getText().split("\\.")[0];
+							int c_n = Integer.parseInt( c_n_string   );
+						
+							if( c_n == cn_h ){
+								cl.setBackground(HIGHLIGHT_COLOUR);
+								cl.setOpaque(true);	
+							}	
+						}
+					}
+					break;										
+				}
+			}
+		
 		}
 		
 		
-		// make all clues white
-		
-		// color appropriate clue
+
 	}
 	
 	
@@ -1317,9 +1362,15 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		}	
 	}
 	
+	
+	
 	public void makeAllCluesWhite(){
 		//make all other clues white
 		for( JTextArea cl : cluesAcr ){
+			cl.setBackground(Color.WHITE);
+			cl.setOpaque(true);											
+		}
+		for( JTextArea cl : cluesDwn ){
 			cl.setBackground(Color.WHITE);
 			cl.setOpaque(true);											
 		}

--- a/src/Crossword/DrawCrossword.java
+++ b/src/Crossword/DrawCrossword.java
@@ -129,9 +129,9 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		height = screenSize.getHeight();
 		
 		font = new Font("Century Gothic", Font.PLAIN, squareSize / 5 * 3);
-		font2 = new Font("Century Gothic", Font.PLAIN, 24);  //across and down headers
+		font2 = new Font("Century Gothic", Font.PLAIN, 24);  // across and down headers
 		font3 = new Font("Century Gothic", Font.PLAIN, 16);  // clues
-		font4 = new Font("Century Gothic", Font.PLAIN, 11);
+		font4 = new Font("Century Gothic", Font.BOLD, 14);  // clue numbers in grid
 		sol = new DrawSolution(grid, x, y, squareSize, "Crossword", this);
 		rand = new Random();
 		

--- a/src/Crossword/DrawCrossword.java
+++ b/src/Crossword/DrawCrossword.java
@@ -46,7 +46,7 @@ import javax.swing.KeyStroke;
  */
 public class DrawCrossword extends JComponent implements ActionListener {
 	private static final long serialVersionUID = 1L;
-	private static int squareSize = 30;
+	private static int squareSize = 38;
 	private String[][] grid;
 	private JTextField[][] boxes;
 	int x, y, frameSizeX, frameSizeY;
@@ -145,6 +145,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		
 		crosswordGrid.setOpaque(false);  
  		
+		// JTextArea array for actual functional crossword grid.
 		boxes = new JTextField[x - 2][y - 2];
 		border = BorderFactory.createLineBorder(Color.BLACK);
 	
@@ -237,11 +238,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		 */
 		
 		
-		//clue = new JPanel(new FlowLayout(FlowLayout.LEFT , 0, 5));
-		//clue = new JPanel(new FlowLayout());
-		clue = new JPanel(new GridBagLayout());
-		
-		
+		clue = new JPanel(new GridBagLayout());		
 //		clue.setMinimumSize(new Dimension(squareSize * (x - 1), squareSize * (x - 1)));
 		clue.setMinimumSize(new Dimension( 200, 600)  );
 		c = new GridBagConstraints();
@@ -264,15 +261,16 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		
 		hints = new ArrayList<JTextArea>();
 
-		//JLabel first = new JLabel("Across");   // STEVE JTEXTARE FOR WRAPPING
+		//JLabel first = new JLabel("Across");   
 		JTextArea first = new JTextArea("Across\n");   // STEVE JTEXTARE FOR WRAPPING
-
+		first.setEditable(false);
 		first.setFont(font2);
-		//first.setSize(100,1);
 		
 		//add space at top
-		cluesAcr.add(new JTextArea(""));
-		//
+		JTextArea blnk = new JTextArea("");
+		blnk.setEditable(false);
+		cluesAcr.add(blnk);
+		
 		cluesAcr.add(first);
 		
 		
@@ -287,6 +285,8 @@ public class DrawCrossword extends JComponent implements ActionListener {
 			
 			String clue = s + " (" + len + ")";
 			JTextArea across = new JTextArea(clue);
+			across.setEditable(false);
+			
 			//add word length here.
 			
 			across.setFont(font3);
@@ -297,7 +297,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 			mouseActionlabel(across);
 			mouseActionlabel(hintA);
 			
-			across.setLineWrap(true);
+			across.setLineWrap(true); /// all set manually for down clues aswell. see below. make sure consistent.
 		    across.setWrapStyleWord(true);
 		    //across.setSize(100,1);
 		    across.setColumns(25); 
@@ -313,8 +313,9 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		
 		JTextArea second = new JTextArea("Down\n");
 		//add space at top
-		cluesAcr.add(new JTextArea(""));
+		cluesDwn.add( blnk );
 		//
+		second.setEditable(false);
 		second.setFont(font2);
 		cluesDwn.add(second);
 		
@@ -328,6 +329,8 @@ public class DrawCrossword extends JComponent implements ActionListener {
 			String clue = s + " (" + len + ")";
 			JTextArea down = new JTextArea(clue);
 			down.setFont(font3);
+			down.setEditable(false);
+			
 			hintD = new JTextArea(" ");
 			hintD.setFont(font3);
 			hintD.setForeground(Color.BLUE);
@@ -349,7 +352,10 @@ public class DrawCrossword extends JComponent implements ActionListener {
 			c.weighty = 1;
 			c.gridx = 0;
 			clue.add(j,c);
-			clue.add(new JTextArea(""), c);
+			
+			JTextArea blankline = new JTextArea("");
+			blankline.setEditable(false);
+			clue.add(blankline, c);//spacing between clues
 		}
 
 		for (JTextArea k : cluesDwn) {
@@ -357,9 +363,17 @@ public class DrawCrossword extends JComponent implements ActionListener {
 			c2.weighty = 1;
 			c2.gridx = 0;
 			clue2.add(k, c);
-			clue2.add(new JTextArea(""),c);
+			
+			JTextArea blankline = new JTextArea("");
+			blankline.setEditable(false);
+			clue2.add(blankline,c);
 		}
 
+		
+		
+		
+		clue.setBorder(border);
+		clue2.setBorder(border);
 
 		
 		// Add the 2 clue JPanels to flow JPanel

--- a/src/Crossword/DrawCrossword.java
+++ b/src/Crossword/DrawCrossword.java
@@ -27,6 +27,7 @@ import javax.swing.JLayeredPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTextField;
+import javax.swing.JTextArea;
 import javax.swing.border.Border;
 import javax.swing.text.DefaultEditorKit;
 // Steve: need these to remove automatic arrow key scrolling in JScrollPane
@@ -47,13 +48,14 @@ public class DrawCrossword extends JComponent implements ActionListener {
 	private String[][] grid;
 	private JTextField[][] boxes;
 	int x, y, frameSizeX, frameSizeY;
-	JPanel panel, crosswordGrid, clue, clueNums, main;
+	JPanel panel, crosswordGrid, clue, clue2, clueNums, main;
 	JLayeredPane layer;
 	JScrollPane area;
 	JButton reveal;
 	JLabel[][] clueNumbers;
-	ArrayList<JLabel> cluesDwn, cluesAcr, hints;
+	ArrayList<JTextArea> cluesDwn, cluesAcr, hints;
 	GridBagConstraints c;
+	GridBagConstraints c2;
 	ArrayList<JLabel> nums;
 	ArrayList<Entry> entries;
 	DrawSolution sol;
@@ -61,13 +63,15 @@ public class DrawCrossword extends JComponent implements ActionListener {
 	Random rand;
 	Border border;
 	Color clear, red, green, blue, black;
-	JLabel hintD, hintA;
+	JTextArea hintD, hintA;
 	ArrayList<KeyEvent> keys;
 	Action action;
 	Dimension screenSize;
 	double width;
 	double height;
 	JPanel flow;
+	//JPanel flow2;
+	
 	
 	// Define color highlighting current word
 	Color HIGHLIGHT_COLOUR = new Color(20,100,20,100) ;
@@ -102,9 +106,11 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		keys = new ArrayList<KeyEvent>();
 		
 		flow = new JPanel(new FlowLayout());
+		//flow2 = new JPanel(new FlowLayout());
 
-		cluesDwn = new ArrayList<JLabel>();
-		cluesAcr = new ArrayList<JLabel>();
+		
+		cluesDwn = new ArrayList<JTextArea>();
+		cluesAcr = new ArrayList<JTextArea>();
 		clear = new Color(255, 255, 255, 255);
 		red = new Color(255, 0, 0, 255);
 		green = new Color(0, 255, 0, 255);
@@ -232,12 +238,29 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		c.fill = GridBagConstraints.BOTH;
 		clue.setBackground(clear);
 		clue.setAlignmentY(0);
-		clue.setBounds(300, 300, 200, 200);
-		hints = new ArrayList<JLabel>();
+		//clue.setBounds(200, 200, 200, 200);
+		
+		clue2 = new JPanel(new GridBagLayout());
+		clue2.setMinimumSize(new Dimension(squareSize * (x - 1), squareSize * (x - 1)));
+		c2 = new GridBagConstraints();
+		c2.fill = GridBagConstraints.BOTH;
+		clue2.setBackground(clear);
+		clue2.setAlignmentY(0);
+		//clue2.setBounds(200, 200, 200, 200);
+		
+		
+		
+		hints = new ArrayList<JTextArea>();
 
-		JLabel first = new JLabel("Across");
+		//JLabel first = new JLabel("Across");   // STEVE JTEXTARE FOR WRAPPING
+		JTextArea first = new JTextArea("Across\n");   // STEVE JTEXTARE FOR WRAPPING
+
 		first.setFont(font2);
+		//first.setSize(100,1);
+		
 		cluesAcr.add(first);
+		
+		
 		int len = 0;
 		for (String s : cluesAcross) {
 			for(Entry e: entries){
@@ -247,24 +270,32 @@ public class DrawCrossword extends JComponent implements ActionListener {
 			}
 			
 			String clue = s + " (" + len + ")";
-			JLabel across = new JLabel(clue);
+			JTextArea across = new JTextArea(clue);
 			//add word length here.
 			
 			across.setFont(font3);
-			hintA = new JLabel(" ");
+			hintA = new JTextArea(" ");
 			hintA.setFont(font3);
 			hintA.setForeground(Color.BLUE);
 			hints.add(hintA);
 			mouseActionlabel(across);
 			mouseActionlabel(hintA);
+			
+			across.setLineWrap(true);
+		    across.setWrapStyleWord(true);
+		    //across.setSize(100,1);
+		    across.setColumns(25); 
+
+			
 			cluesAcr.add(across);
+			
 			//cluesAcr.add(hintA);  //STEVE REMOVE
 		}
 
 
 
 		
-		JLabel second = new JLabel("Down\n");
+		JTextArea second = new JTextArea("Down\n");
 		second.setFont(font2);
 		cluesDwn.add(second);
 		for (String s : cluesDown) {
@@ -274,36 +305,48 @@ public class DrawCrossword extends JComponent implements ActionListener {
 				}
 			}
 			String clue = s + " (" + len + ")";
-			JLabel down = new JLabel(clue);
+			JTextArea down = new JTextArea(clue);
 			down.setFont(font3);
-			hintD = new JLabel(" ");
+			hintD = new JTextArea(" ");
 			hintD.setFont(font3);
 			hintD.setForeground(Color.BLUE);
 			hints.add(hintD);
 			mouseActionlabel(down);
 			mouseActionlabel(hintD);
+			
+			down.setLineWrap(true);
+		    down.setWrapStyleWord(true);
+		    //across.setSize(100,1);
+		    down.setColumns(25); 
+			
 			cluesDwn.add(down);
 			//cluesDwn.add(hintD);  // STEVE REMOVE
 		}
 
-		for (JLabel j : cluesAcr) {
+		for (JTextArea j : cluesAcr) {
 			c.weightx = 1.0;
-			c.weighty = 0.3;
+			c.weighty = 1;
 			c.gridx = 0;
-			clue.add(j, c);
+			clue.add(j,c);
 		}
 
-		for (JLabel k : cluesDwn) {
-			c.weightx = 1.0;
-			c.weighty = 0.3;
-			c.gridx = 0;
-			clue.add(k, c);
+		for (JTextArea k : cluesDwn) {
+			c2.weightx = 1.0;
+			c2.weighty = 1;
+			c2.gridx = 20;
+			clue2.add(k, c);
 		}
 
 		
 		flow.add(clue);
 		flow.setBorder(null);
 		flow.setBackground(clear);
+		
+		flow.add(clue2);
+		
+//		flow2.add(clue2);
+//		flow2.setBorder(null);
+//		flow2.setBackground(clear);
 		
 		
 		/**
@@ -329,6 +372,9 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		c.gridy = 0;
 		c.anchor = GridBagConstraints.FIRST_LINE_START;
 		main.add(flow, c);
+		
+		
+		//main.add(flow2,c2);
 		
 
 //		c.weighty = 1.0;
@@ -675,7 +721,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 
 	
 	// MOUSE ACTIONS on JLabel (hints) here ---------------------
-	void mouseActionlabel(JLabel l) {
+	void mouseActionlabel(JTextArea l) {
 		
 		
 		l.addMouseListener(new MouseListener() {
@@ -767,7 +813,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 				
 				firsteverclick = false;
 				
-				for( JLabel cl : cluesAcr ){
+				for( JTextArea cl : cluesAcr ){
 					if( e.getSource()==cl ){
 						cl.setBackground(HIGHLIGHT_COLOUR);
 						cl.setOpaque(true);	
@@ -791,7 +837,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 					}
 			
 				}
-				for( JLabel cl : cluesDwn ){
+				for( JTextArea cl : cluesDwn ){
 					if( e.getSource()==cl ){
 						cl.setBackground(HIGHLIGHT_COLOUR);
 						cl.setOpaque(true);	
@@ -831,14 +877,14 @@ public class DrawCrossword extends JComponent implements ActionListener {
 //					}
 //				}   // STEVE REMOVE
 
-				for( JLabel cl : cluesAcr ){
+				for( JTextArea cl : cluesAcr ){
 					if( e.getSource()==cl ){
 						cl.setBackground(Color.WHITE);
 						cl.setOpaque(true);						
 					}
 			
 				}
-				for( JLabel cl : cluesDwn ){
+				for( JTextArea cl : cluesDwn ){
 					cl.setBackground(Color.WHITE);
 					cl.setOpaque(true);							
 				}

--- a/src/Crossword/DrawCrossword.java
+++ b/src/Crossword/DrawCrossword.java
@@ -106,8 +106,6 @@ public class DrawCrossword extends JComponent implements ActionListener {
 
 		keys = new ArrayList<KeyEvent>();
 		
-		flow = new JPanel(new FlowLayout(FlowLayout.LEFT , 200, 0));
-		//flow2 = new JPanel(new FlowLayout());
 
 		
 		cluesDwn = new ArrayList<JTextArea>();
@@ -375,14 +373,35 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		//clue.setBorder(border);
 		//clue2.setBorder(border);
 
+		clue.setAlignmentY(0);
+		clue2.setAlignmentY(0);
+		clue.setAlignmentX(0);
+		clue2.setAlignmentX(0);
+		
+	    GridBagConstraints zzz = new GridBagConstraints();
+		zzz.fill = GridBagConstraints.HORIZONTAL;
+		zzz.gridx=0;
+		zzz.gridy=0;
+		
+		
+		
+		flow = new JPanel(new FlowLayout(FlowLayout.LEFT , 100, 0));
+		////flow = new JPanel(new GridLayout(2,4,1,1));
+
+		
+		//flow = new JPanel(new FlowLayout(FlowLayout.CENTER , 200, 0));
+
+		//flow = new JPanel();
+//		flow.add(clue );
+//		flow.add(clue2 );		
 		
 		// Add the 2 clue JPanels to flow JPanel
-		flow.add(clue );
-		flow.add(clue2 );
+		flow.add(clue, zzz );
+		flow.add(clue2, zzz );
 
 		flow.setBackground(clear);
 		
-		flow.setBorder( BorderFactory.createEmptyBorder(0, -200, 0, 0) ); 
+		//flow.setBorder( BorderFactory.createEmptyBorder(0, -200, 0, 0) ); 
 		// THE FLOWLAYOUT I HAVE USED PUTS HAS X AND Y SPACINGS DEFINED. THIS ALSO INCLUDES A SPACE BEFORE THE FIRST COMPONENT
 		// WHICH IS NOT WHAT WE WANT, SO THIS IS TO REMOVE THAT. THE -VE NUMBER HAS TO MATCH THAT ABOVE IN FLOWLAYOUT
 		

--- a/src/Crossword/DrawCrossword.java
+++ b/src/Crossword/DrawCrossword.java
@@ -584,9 +584,11 @@ public class DrawCrossword extends JComponent implements ActionListener {
 										boxes[ (newstart-i) ][col].requestFocus();
 										// highlight any words that *start* from this square
 										highlightWord( newstart-i, col);
+										colorAppropriateClue();
 										break;
 									}
-								}												
+								}	
+								
 							}
 							if (e.getKeyCode() == KeyEvent.VK_DOWN) {						
 								makeAllWhite();
@@ -725,7 +727,16 @@ public class DrawCrossword extends JComponent implements ActionListener {
 							}
 						}
 					}
+
 				}
+				
+				
+				
+				// After any keypress, if any grids highlighted, highlight appropriate clue
+				//colorAppropriateClue();
+				// method checks for highlighted square, gets direction, gets clue number, highlights clue
+				
+				
 			}
 
 			public void keyReleased(KeyEvent e) {
@@ -883,9 +894,10 @@ public class DrawCrossword extends JComponent implements ActionListener {
 //							i.setText("      HINT");
 //						}
 //					}
-//				}    STEVE REMOVE
-				
+//				}    STEVE REMOVE				
 				firsteverclick = false;
+				
+				makeAllCluesWhite();
 				
 				for( JTextArea cl : cluesAcr ){
 					if( e.getSource()==cl ){
@@ -1139,6 +1151,12 @@ public class DrawCrossword extends JComponent implements ActionListener {
 	
 	
 	
+	
+	
+	
+	
+	
+	
 	public void highlightWord_fromClick( int xstart, int ystart ){		
 		/** Highlight from mouse clicks. Across/down depends on number of clicks **/
 		
@@ -1206,6 +1224,88 @@ public class DrawCrossword extends JComponent implements ActionListener {
 	
 	
 	
+	
+	
+	
+	public void colorAppropriateClue(){
+		
+		// get a coloured square
+		int coloredX=0;  int coloredY=0;
+		for( int abc=0; abc<x-2; abc++ ){
+			for( int xyz=0; xyz<y-2; xyz++ ){
+				if( boxes[abc][xyz].getBackground().getRGB() == HIGHLIGHT_COLOUR.getRGB()  ){  // mioght be better to check it is the highlight color and not just "not white"
+					coloredY = abc;  coloredX = xyz;
+					//break;
+				}
+			}
+		}
+		
+		System.out.println( coloredY + "  " + coloredX  );
+		
+		// get the direction
+		String dd = "";
+		if( (coloredX>0 && boxes[coloredY][coloredX-1].getBackground().getRGB() == HIGHLIGHT_COLOUR.getRGB() )  
+				||   (coloredX<x-3 && boxes[coloredY][coloredX+1].getBackground().getRGB() == HIGHLIGHT_COLOUR.getRGB()  )  ){
+			// across
+			dd = "across";
+		}
+		else if( (coloredY>0 && boxes[coloredY-1][coloredX].getBackground().getRGB() == HIGHLIGHT_COLOUR.getRGB() ) 
+				|| (coloredY<y-3 && boxes[coloredY+1][coloredX].getBackground().getRGB() == HIGHLIGHT_COLOUR.getRGB()  )   ){
+			// down
+			dd = "down"; 
+		}
+		
+		// get clue number 
+		int cn_h = -1;
+		
+		if( dd.equals("across") ){
+			System.out.println("across");
+			for( int gg=0; gg<x-2; gg++ ){
+				
+				if( !clueNumbers[coloredY][coloredX-gg].getText().equals("") ){
+					
+					cn_h = Integer.parseInt( clueNumbers[coloredY][coloredX-gg].getText()  );
+					
+					System.out.println( "clue num:"+ cn_h );
+					
+					makeAllCluesWhite();
+					
+					// highlight appropriate clue
+					for( JTextArea cl : cluesAcr ){		
+						
+						if( cl.getText().contains(".") ){
+							String c_n_string = ""+cl.getText().split("\\.")[0];
+							int c_n = Integer.parseInt( c_n_string   );
+						
+							if( c_n == cn_h ){
+								cl.setBackground(HIGHLIGHT_COLOUR);
+								cl.setOpaque(true);	
+							}	
+						}
+					}
+					break;										
+				}
+
+				
+			}
+		}
+		else if( dd.equalsIgnoreCase("down") ){
+			
+		}
+		
+		
+		// make all clues white
+		
+		// color appropriate clue
+	}
+	
+	
+	
+	
+	
+	
+	
+	
 	public void makeAllWhite(){
 		/** Reset entire grid to white **/ 
 		for (int rrrr = 0; rrrr < x - 2; rrrr++) {
@@ -1215,6 +1315,14 @@ public class DrawCrossword extends JComponent implements ActionListener {
 				}	
 			}
 		}	
+	}
+	
+	public void makeAllCluesWhite(){
+		//make all other clues white
+		for( JTextArea cl : cluesAcr ){
+			cl.setBackground(Color.WHITE);
+			cl.setOpaque(true);											
+		}
 	}
 
 	

--- a/src/Crossword/DrawCrossword.java
+++ b/src/Crossword/DrawCrossword.java
@@ -210,6 +210,10 @@ public class DrawCrossword extends JComponent implements ActionListener {
 				clueNums.add(clueNumbers[i][j]);
 			}
 		}
+		
+		
+		
+		
 
 		/**
 		 * This is the JLayeredPane layer which holds the actual crossword. It
@@ -226,16 +230,17 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		layer.setVisible(true);
 		layer.setOpaque(true);
 		layer.setPreferredSize(new Dimension(squareSize * (x), squareSize * (y)));
-		layer.setMinimumSize(new Dimension(squareSize * (x - 1), squareSize * (x - 1)));
+		//layer.setMinimumSize(new Dimension(squareSize * (x - 1), squareSize * (x - 1)));
+		layer.setMinimumSize(new Dimension(squareSize * x, squareSize * x)  ); /// CHANGING THESE DIMENSKONS AFFECTS NOTHING
 
 
+		
+		
+		
 		/**
 		 * This is the GridBagLayout clue which holds all the clue components:
 		 * The numbers and clues in a JTextArea and the hints in a JLabel
 		 */
-		
-		
-		
 		
 		// Two JPanels for holding across and down clues. Will hold these as JTextAreas with GridBagLayout c3.
 		
@@ -289,6 +294,8 @@ public class DrawCrossword extends JComponent implements ActionListener {
 			String clue = s + " (" + len + ")";
 			JTextArea across = new JTextArea(clue);
 			across.setEditable(false);
+			across.setHighlighter(null);
+			//across.setEnabled(false);
 			
 			//add word length here.
 			
@@ -401,7 +408,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 
 		flow.setBackground(clear);
 		
-		//flow.setBorder( BorderFactory.createEmptyBorder(0, -200, 0, 0) ); 
+		flow.setBorder( BorderFactory.createEmptyBorder(0, -100, 0, 0) ); 
 		// THE FLOWLAYOUT I HAVE USED PUTS HAS X AND Y SPACINGS DEFINED. THIS ALSO INCLUDES A SPACE BEFORE THE FIRST COMPONENT
 		// WHICH IS NOT WHAT WE WANT, SO THIS IS TO REMOVE THAT. THE -VE NUMBER HAS TO MATCH THAT ABOVE IN FLOWLAYOUT
 		
@@ -499,6 +506,9 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		c.ipady = 10;
 		panel.add(reveal, c);
 
+		
+		
+		
 		/**
 		 * Overall JFrame to hold all components This has the main panel
 		 * assigned to it

--- a/src/Crossword/DrawCrossword.java
+++ b/src/Crossword/DrawCrossword.java
@@ -56,8 +56,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 	JButton reveal;
 	JLabel[][] clueNumbers;
 	ArrayList<JTextArea> cluesDwn, cluesAcr, hints;
-	GridBagConstraints c;
-	GridBagConstraints c2;
+	GridBagConstraints c, c2, c3, gbc_main;
 	ArrayList<JLabel> nums;
 	ArrayList<Entry> entries;
 	DrawSolution sol;
@@ -238,11 +237,13 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		 */
 		
 		
+		
+		
+		// Two JPanels for holding across and down clues. Will hold these as JTextAreas with GridBagLayout c3.
+		
 		clue = new JPanel(new GridBagLayout());		
 //		clue.setMinimumSize(new Dimension(squareSize * (x - 1), squareSize * (x - 1)));
 		clue.setMinimumSize(new Dimension( 200, 600)  );
-		c = new GridBagConstraints();
-		c.fill = GridBagConstraints.BOTH;
 		clue.setBackground(clear);
 		clue.setAlignmentY(0);
 		clue.setAlignmentX(0);
@@ -251,26 +252,30 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		clue2 = new JPanel(new GridBagLayout()     );
 //		clue2.setMinimumSize(new Dimension(squareSize * (x - 1), squareSize * (x - 1)));
 		clue2.setMinimumSize(new Dimension(200 ,  600 )  );
-		c2 = new GridBagConstraints();
-		c2.fill = GridBagConstraints.BOTH;
 		clue2.setBackground(clear);
 		clue2.setAlignmentY(0);
 		//clue2.setBounds(200, 200, 200, 200);
+		
+		// GridBagLayout for clue JPanels. This is how the clues will be arranged inside the JPanel.
+		c3 = new GridBagConstraints();
+		c3.fill = GridBagConstraints.BOTH;
+		c3.weightx = 1.0;
+		c3.weighty = 1;
+		c3.gridx = 0;
+		
 		
 		
 		
 		hints = new ArrayList<JTextArea>();
 
-		//JLabel first = new JLabel("Across");   
-		JTextArea first = new JTextArea("Across\n");   // STEVE JTEXTARE FOR WRAPPING
-		first.setEditable(false);
-		first.setFont(font2);
 		
-		//add space at top
+		//add space at top and "Across" title
 		JTextArea blnk = new JTextArea("");
 		blnk.setEditable(false);
 		cluesAcr.add(blnk);
-		
+		JTextArea first = new JTextArea("Across\n");   // STEVE JTEXTARE FOR WRAPPING
+		first.setEditable(false);
+		first.setFont(font2);		
 		cluesAcr.add(first);
 		
 		
@@ -297,12 +302,10 @@ public class DrawCrossword extends JComponent implements ActionListener {
 			mouseActionlabel(across);
 			mouseActionlabel(hintA);
 			
-			across.setLineWrap(true); /// all set manually for down clues aswell. see below. make sure consistent.
+			across.setLineWrap(true); // all set manually for down clues as well. see below. make sure consistent.
 		    across.setWrapStyleWord(true);
-		    //across.setSize(100,1);
-		    across.setColumns(25); 
+		    across.setColumns(25);   // CONTROLS HOW FAR TO GO BEFORE WRAPPING LINE
 
-			
 			cluesAcr.add(across);
 			
 			//cluesAcr.add(hintA);  //STEVE REMOVE
@@ -310,11 +313,9 @@ public class DrawCrossword extends JComponent implements ActionListener {
 
 
 
-		
-		JTextArea second = new JTextArea("Down\n");
-		//add space at top
+		//add space at top and "Down" title
 		cluesDwn.add( blnk );
-		//
+		JTextArea second = new JTextArea("Down\n");
 		second.setEditable(false);
 		second.setFont(font2);
 		cluesDwn.add(second);
@@ -340,60 +341,56 @@ public class DrawCrossword extends JComponent implements ActionListener {
 			
 			down.setLineWrap(true);
 		    down.setWrapStyleWord(true);
-		    //across.setSize(100,1);
 		    down.setColumns(25); 
 			
 			cluesDwn.add(down);
 			//cluesDwn.add(hintD);  // STEVE REMOVE
 		}
+		
+		
+
 
 		for (JTextArea j : cluesAcr) {
-			c.weightx = 1.0;
-			c.weighty = 1;
-			c.gridx = 0;
-			clue.add(j,c);
-			
+
+			clue.add(j, c3);
+
 			JTextArea blankline = new JTextArea("");
 			blankline.setEditable(false);
-			clue.add(blankline, c);//spacing between clues
+			clue.add(blankline, c3);//spacing between clues
+
 		}
 
 		for (JTextArea k : cluesDwn) {
-			c2.weightx = 1.0;
-			c2.weighty = 1;
-			c2.gridx = 0;
-			clue2.add(k, c);
+
+			clue2.add(k, c3);
 			
 			JTextArea blankline = new JTextArea("");
 			blankline.setEditable(false);
-			clue2.add(blankline,c);
+			clue2.add(blankline,c3);
 		}
 
 		
 		
 		
-		clue.setBorder(border);
-		clue2.setBorder(border);
+		//clue.setBorder(border);
+		//clue2.setBorder(border);
 
 		
 		// Add the 2 clue JPanels to flow JPanel
-		flow.add(clue, BorderLayout.CENTER );
-		flow.add(clue2, BorderLayout.EAST );
+		flow.add(clue );
+		flow.add(clue2 );
 
-		
-		flow.setBorder(null);
 		flow.setBackground(clear);
-		
 		
 		flow.setBorder( BorderFactory.createEmptyBorder(0, -200, 0, 0) ); 
 		// THE FLOWLAYOUT I HAVE USED PUTS HAS X AND Y SPACINGS DEFINED. THIS ALSO INCLUDES A SPACE BEFORE THE FIRST COMPONENT
 		// WHICH IS NOT WHAT WE WANT, SO THIS IS TO REMOVE THAT. THE -VE NUMBER HAS TO MATCH THAT ABOVE IN FLOWLAYOUT
 		
 		
+
 		
-//		flow2.add(clue2);
-//		flow2.setBorder(null);
-//		flow2.setBackground(clear);
+		
+		
 		
 		
 		/**
@@ -405,34 +402,25 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		main = new JPanel(new GridBagLayout());
 		main.setBackground(clear);
 		
-
+		gbc_main = new GridBagConstraints();
+		gbc_main.weighty = 1.0;
+		gbc_main.weightx = 1.0;
+		gbc_main.gridx = 0;
+		gbc_main.gridy = 0;
+		
+		gbc_main.fill = GridBagConstraints.BOTH;
+		
+		//layer.setAlignmentY(0);
+		main.add(layer, gbc_main);
 		
 
-		c.weighty = 1.0;
-		c.weightx = 1.0;
-		c.gridx = 0;
-		c.gridy = 0;
-		main.add(layer, c);
+		gbc_main.gridx = 1; // NEED THIS
 		
-		c.weighty = 1.0;
-		c.weightx = 1.0;
-		c.gridx = 1;
-		c.gridy = 0;
-		//c.anchor = GridBagConstraints.FIRST_LINE_START;
+		//flow.setAlignmentY(0);
+		main.add(flow, gbc_main);
 		
 		
-		
-		main.add(flow, c);
-		
-		
-		//main.add(flow2,c2);
-//		c.weighty = 1.0;
-//		c.weightx = 1.0;
-//		c.gridx = 1;
-//		c.gridy = 0;
-//		main.add(clue, c);
 
-		
 		
 		
 		
@@ -476,6 +464,9 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		 */
 		panel = new JPanel(new GridBagLayout());
 
+		c = new GridBagConstraints();
+		c.fill = GridBagConstraints.BOTH;
+		
 		c.weighty = 1.0;
 		c.ipadx = 1;
 		c.gridx = 0;

--- a/src/Crossword/DrawCrossword.java
+++ b/src/Crossword/DrawCrossword.java
@@ -75,7 +75,9 @@ public class DrawCrossword extends JComponent implements ActionListener {
 	
 	
 	// Define color highlighting current word
-	Color HIGHLIGHT_COLOUR = new Color(20,100,20,100) ;
+	//Color HIGHLIGHT_COLOUR = new Color(20,100,20,100) ;
+	// STOP USING TRANSPARENCY AND JUST USE (R,G,B) TRIPLET.  STUFF KEEPS OVERLAPPING
+	Color HIGHLIGHT_COLOUR = new Color( 163 , 194,  163);
 	
 	
 	//tracking clicks
@@ -559,7 +561,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 					firsteverclick=false;
 				}
 
-				makeAllCluesWhite();
+				//makeAllCluesWhite();
 					
 						
 				
@@ -740,8 +742,8 @@ public class DrawCrossword extends JComponent implements ActionListener {
 							}
 							
 							
-//							makeAllCluesWhite();
-//							colorAppropriateClue();
+							makeAllCluesWhite();
+							colorAppropriateClue();
 
 							
 							
@@ -801,7 +803,12 @@ public class DrawCrossword extends JComponent implements ActionListener {
 						//	lb.setText(" ");
 						//}
 					}
-				}			
+				}
+				
+				// higlhight approp. clue
+				makeAllCluesWhite();
+				colorAppropriateClue();
+				
 			}
 			
 			public void mouseEntered(MouseEvent e) {
@@ -1248,6 +1255,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 	
 	
 	public void colorAppropriateClue(){
+		/** Highlight clue of any word that is highlighted in grid **/
 		
 		makeAllCluesWhite();
 		

--- a/src/Crossword/DrawCrossword.java
+++ b/src/Crossword/DrawCrossword.java
@@ -1,4 +1,5 @@
 package Crossword;
+import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
@@ -139,7 +140,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		 * This is where all the crossword boxes are filled black or provide a
 		 * usable JTextfield. This is layered on top of the transparentLayer
 		 */
-		crosswordGrid = new JPanel(new GridLayout(x - 2, y - 2));
+		crosswordGrid = new JPanel(new GridLayout(x-2 , y-2 ));
 		crosswordGrid.setBounds(squareSize, squareSize, squareSize * (x - 2), squareSize * (y - 2));
 		
 		crosswordGrid.setOpaque(false);  
@@ -241,20 +242,22 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		clue = new JPanel(new GridBagLayout());
 		
 		
-		clue.setMinimumSize(new Dimension(squareSize * (x - 1), squareSize * (x - 1)));
+//		clue.setMinimumSize(new Dimension(squareSize * (x - 1), squareSize * (x - 1)));
+		clue.setMinimumSize(new Dimension( 200, 600)  );
 		c = new GridBagConstraints();
 		c.fill = GridBagConstraints.BOTH;
 		clue.setBackground(clear);
-		//clue.setAlignmentY(0);
+		clue.setAlignmentY(0);
 		clue.setAlignmentX(0);
 		//clue.setBounds(200, 200, 200, 200);
 		
 		clue2 = new JPanel(new GridBagLayout()     );
-		clue2.setMinimumSize(new Dimension(squareSize * (x - 1), squareSize * (x - 1)));
+//		clue2.setMinimumSize(new Dimension(squareSize * (x - 1), squareSize * (x - 1)));
+		clue2.setMinimumSize(new Dimension(200 ,  600 )  );
 		c2 = new GridBagConstraints();
 		c2.fill = GridBagConstraints.BOTH;
 		clue2.setBackground(clear);
-		//clue2.setAlignmentY(0);
+		clue2.setAlignmentY(0);
 		//clue2.setBounds(200, 200, 200, 200);
 		
 		
@@ -267,7 +270,11 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		first.setFont(font2);
 		//first.setSize(100,1);
 		
+		//add space at top
+		cluesAcr.add(new JTextArea(""));
+		//
 		cluesAcr.add(first);
+		
 		
 		
 		int len = 0;
@@ -305,8 +312,13 @@ public class DrawCrossword extends JComponent implements ActionListener {
 
 		
 		JTextArea second = new JTextArea("Down\n");
+		//add space at top
+		cluesAcr.add(new JTextArea(""));
+		//
 		second.setFont(font2);
 		cluesDwn.add(second);
+		
+		
 		for (String s : cluesDown) {
 			for(Entry e: entries){
 				if(e.definition.equals(s)){
@@ -337,6 +349,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 			c.weighty = 1;
 			c.gridx = 0;
 			clue.add(j,c);
+			clue.add(new JTextArea(""), c);
 		}
 
 		for (JTextArea k : cluesDwn) {
@@ -344,14 +357,19 @@ public class DrawCrossword extends JComponent implements ActionListener {
 			c2.weighty = 1;
 			c2.gridx = 0;
 			clue2.add(k, c);
+			clue2.add(new JTextArea(""),c);
 		}
 
+
 		
-		flow.add(clue);
+		// Add the 2 clue JPanels to flow JPanel
+		flow.add(clue, BorderLayout.CENTER );
+		flow.add(clue2, BorderLayout.EAST );
+
+		
 		flow.setBorder(null);
 		flow.setBackground(clear);
 		
-		flow.add(clue2);
 		
 		flow.setBorder( BorderFactory.createEmptyBorder(0, -200, 0, 0) ); 
 		// THE FLOWLAYOUT I HAVE USED PUTS HAS X AND Y SPACINGS DEFINED. THIS ALSO INCLUDES A SPACE BEFORE THE FIRST COMPONENT
@@ -386,19 +404,25 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		c.weightx = 1.0;
 		c.gridx = 1;
 		c.gridy = 0;
-		c.anchor = GridBagConstraints.FIRST_LINE_START;
+		//c.anchor = GridBagConstraints.FIRST_LINE_START;
+		
+		
+		
 		main.add(flow, c);
 		
 		
 		//main.add(flow2,c2);
-		
-
 //		c.weighty = 1.0;
 //		c.weightx = 1.0;
 //		c.gridx = 1;
 //		c.gridy = 0;
 //		main.add(clue, c);
 
+		
+		
+		
+		
+		
 		/**
 		 * This is the largest area of the GUI which holds the crossword and
 		 * clues pane and makes them scrollable.

--- a/src/Crossword/DrawCrossword.java
+++ b/src/Crossword/DrawCrossword.java
@@ -71,13 +71,10 @@ public class DrawCrossword extends JComponent implements ActionListener {
 	double width;
 	double height;
 	JPanel flow;
-	//JPanel flow2;
 	
 	
-	// Define color highlighting current word
-	//Color HIGHLIGHT_COLOUR = new Color(20,100,20,100) ;
-	// STOP USING TRANSPARENCY AND JUST USE (R,G,B) TRIPLET.  STUFF KEEPS OVERLAPPING
-	Color HIGHLIGHT_COLOUR = new Color( 163 , 194,  163);
+	// Define Color highlighting current word & clue
+	Color HIGHLIGHT_COLOUR = new Color( 163 , 194,  163);  //( = faded forest green )
 	
 	
 	//tracking clicks
@@ -128,7 +125,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		height = screenSize.getHeight();
 		
 		font = new Font("Century Gothic", Font.PLAIN, squareSize / 5 * 3);
-		font2 = new Font("Century Gothic", Font.PLAIN, 24);  // across and down headers
+		font2 = new Font("Century Gothic", Font.PLAIN, 26);  // across and down headers + actual crossword letters
 		font3 = new Font("Century Gothic", Font.PLAIN, 16);  // clues
 		font4 = new Font("Century Gothic", Font.BOLD, 14);  // clue numbers in grid
 		sol = new DrawSolution(grid, x, y, squareSize, "Crossword", this);
@@ -242,9 +239,8 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		/**
 		 * This is the GridBagLayout clue which holds all the clue components:
 		 * The numbers and clues in a JTextArea and the hints in a JLabel
-		 */
-		
-		// Two JPanels for holding across and down clues. Will hold these as JTextAreas with GridBagLayout c3.
+		 */	
+		// ( Two JPanels for holding across and down clues. Will hold these as JTextAreas with GridBagLayout c3 )
 		
 		clue = new JPanel(new GridBagLayout());		
 //		clue.setMinimumSize(new Dimension(squareSize * (x - 1), squareSize * (x - 1)));
@@ -296,7 +292,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 			String clue = s + " (" + len + ")";
 			JTextArea across = new JTextArea(clue);
 			across.setEditable(false);
-			across.setHighlighter(null);
+			across.setHighlighter(null);  // WHY DOES THIS OD NOTHING?
 			//across.setEnabled(false);
 			
 			//add word length here.
@@ -309,7 +305,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 			mouseActionlabel(across);
 			mouseActionlabel(hintA);
 			
-			across.setLineWrap(true); // all set manually for down clues as well. see below. make sure consistent.
+			across.setLineWrap(true); 
 		    across.setWrapStyleWord(true);
 		    across.setColumns(25);   // CONTROLS HOW FAR TO GO BEFORE WRAPPING LINE
 
@@ -378,9 +374,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 
 		
 		
-		
-		//clue.setBorder(border);
-		//clue2.setBorder(border);
+
 
 		clue.setAlignmentY(0);
 		clue2.setAlignmentY(0);
@@ -519,7 +513,6 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		if(squareSize*(x+2)+squareSize/2 > width && squareSize*(y+2) > height-30){
 			//frame.setPreferredSize(new Dimension((int)width,(int)height));
 			frame.setPreferredSize(new Dimension((int)width,(int)height-30));
-			//System.out.println("GOt here");
 		}
 		else if(squareSize*(x+2)+squareSize/2 > width){
 			frame.setPreferredSize(new Dimension((int)width,squareSize*(y+4)));
@@ -560,9 +553,6 @@ public class DrawCrossword extends JComponent implements ActionListener {
 					highlightWord_fromClick(lastClick_x,lastClick_y);
 					firsteverclick=false;
 				}
-
-				//makeAllCluesWhite();
-					
 						
 				
 				
@@ -571,7 +561,6 @@ public class DrawCrossword extends JComponent implements ActionListener {
 						
 						
 						if (e.getSource() == boxes[row][col]) {
-							makeAllCluesWhite();
 							
 							if (e.getKeyCode() == KeyEvent.VK_UP) {			
 								// get rid of all previous highlighting
@@ -588,12 +577,9 @@ public class DrawCrossword extends JComponent implements ActionListener {
 										boxes[ (newstart-i) ][col].requestFocus();
 										// highlight any words that *start* from this square
 										highlightWord( newstart-i, col);
-//										colorAppropriateClue();
 										break;
 									}
 								}	
-								//makeAllCluesWhite();
-								//colorAppropriateClue();
 							}
 							if (e.getKeyCode() == KeyEvent.VK_DOWN) {						
 								makeAllWhite();
@@ -608,8 +594,6 @@ public class DrawCrossword extends JComponent implements ActionListener {
 										break;
 									}						
 								}	
-								//makeAllCluesWhite();
-								//colorAppropriateClue();
 							}
 							if (e.getKeyCode() == KeyEvent.VK_RIGHT) {
 								makeAllWhite();
@@ -623,9 +607,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 										highlightWord(row, newstart+i);
 										break;
 									}
-								}		
-								//makeAllCluesWhite();
-								//colorAppropriateClue();
+								}	
 							}
 							if (e.getKeyCode() == KeyEvent.VK_LEFT) {
 								makeAllWhite();
@@ -640,8 +622,6 @@ public class DrawCrossword extends JComponent implements ActionListener {
 										break;
 									}
 								}	
-								//makeAllCluesWhite();
-								//colorAppropriateClue();
 							}
 							
 							
@@ -719,8 +699,6 @@ public class DrawCrossword extends JComponent implements ActionListener {
 								}
 									
 								
-								//makeAllCluesWhite();
-								//colorAppropriateClue();
 								
 							}
 							
@@ -742,6 +720,8 @@ public class DrawCrossword extends JComponent implements ActionListener {
 							}
 							
 							
+							
+							// Highlight appropriate  clue after every key event
 							makeAllCluesWhite();
 							colorAppropriateClue();
 
@@ -751,13 +731,6 @@ public class DrawCrossword extends JComponent implements ActionListener {
 					}
 
 				}
-				
-				
-				
-				// After any keypress, if any grids highlighted, highlight appropriate clue
-				//colorAppropriateClue();
-				// method checks for highlighted square, gets direction, gets clue number, highlights clue
-				
 				
 			}
 
@@ -805,7 +778,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 					}
 				}
 				
-				// higlhight approp. clue
+				// higjlight approp. clue
 				makeAllCluesWhite();
 				colorAppropriateClue();
 				
@@ -913,7 +886,8 @@ public class DrawCrossword extends JComponent implements ActionListener {
 				
 			}
 
-					/////////////////CHECK THIS!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1
+
+			
 			public void mouseEntered(MouseEvent e) {
 //				for (JLabel i : hints) {
 //					if (e.getSource() == i) {
@@ -921,7 +895,8 @@ public class DrawCrossword extends JComponent implements ActionListener {
 //							i.setText("      HINT");
 //						}
 //					}
-//				}    STEVE REMOVE				
+//				}    STEVE:  REMOVED FOR NOE, WASNT COMPATIBLE WITH HIGHLITING CLUES. DONT KNOW WHY			
+				
 				firsteverclick = false;
 				
 				makeAllCluesWhite();
@@ -932,15 +907,12 @@ public class DrawCrossword extends JComponent implements ActionListener {
 						cl.setOpaque(true);	
 						
 						makeAllWhite();
-						//cl.setBackground(HIGHLIGHT_COLOUR);
-						//cl.setOpaque(true);
+
 						String c_n_string = ""+cl.getText().split("\\.")[0];
 						int c_n = Integer.parseInt( c_n_string   );
-						//System.out.println(c_n);
 						for( Entry ent : entries ){
 							if( ent.getClueNumber() == c_n && ent.isAcross()   ){
 								// then highlight this word
-								//System.out.println( "x="+ent.getX()+ " y="+ent.getY());
 								boxes[ent.getY()-1][ent.getX()-1].requestFocus();
 								colourWord( ent.getY()-1, ent.getX()-1, "across");   // X AND Y COORDS ARE FUCKED UP. FIX THIS. BUG. TODO!!
 							}
@@ -1019,34 +991,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 	
 	
 	
-	
-	// Highlight squares if on start of word
-	public void highlightWord__OLD( int xstart, int ystart ){
-		
-		if( !clueNumbers[xstart][ystart].getText().equals("") ){
-			
-			for( Entry ent : entries ){
-				String nomnom = Integer.toString( ent.getClueNumber()  );
-				if( clueNumbers[xstart][ystart].getText().equals( nomnom ) ){
-					
-					if( ent.isAcross()  ) {
-						int length = ent.getWord().length();
-						for( int dbl=0; dbl<length; dbl++ ){
-							boxes[xstart][ystart+dbl].setBackground(HIGHLIGHT_COLOUR );
-						}													
-					} 
-					else {
-						int length = ent.getWord().length();
-						for( int dbl=0; dbl<length; dbl++ ){
-							boxes[xstart+dbl][ystart].setBackground(HIGHLIGHT_COLOUR );
-						}														
-					}					
-				}
-			}
-		}		
-	}
-	
-	
+
 
 	
 	
@@ -1259,7 +1204,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		
 		makeAllCluesWhite();
 		
-		// get a coloured square
+		// FIND ANY COLOURED SQUARE
 		int coloredX=0;  int coloredY=0;
 		for( int abc=0; abc<x-2; abc++ ){
 			for( int xyz=0; xyz<y-2; xyz++ ){
@@ -1269,36 +1214,31 @@ public class DrawCrossword extends JComponent implements ActionListener {
 				}
 			}
 		}
-		
-		System.out.println( coloredY + "  " + coloredX  );
-		
-		// get the direction
+				
+		// GET DIRECITON
 		String dd = "";
 		if( (coloredX>0 && boxes[coloredY][coloredX-1].getBackground().getRGB() == HIGHLIGHT_COLOUR.getRGB() )  
 				||   (coloredX<x-3 && boxes[coloredY][coloredX+1].getBackground().getRGB() == HIGHLIGHT_COLOUR.getRGB()  )  ){
-			// across
 			dd = "across";
 		}
 		else if( (coloredY>0 && boxes[coloredY-1][coloredX].getBackground().getRGB() == HIGHLIGHT_COLOUR.getRGB() ) 
 				|| (coloredY<y-3 && boxes[coloredY+1][coloredX].getBackground().getRGB() == HIGHLIGHT_COLOUR.getRGB()  )   ){
-			// down
 			dd = "down"; 
 		}
 		
-		// get clue number 
+		// GET CLUE NUMBER AT START OF WORD 
 		int cn_h = -1;
 		
 		if( dd.equalsIgnoreCase("across") ){
-			System.out.println("across");
+
 			for( int gg=0; gg<x-2; gg++ ){
 				
 				if( (!clueNumbers[coloredY][coloredX-gg].getText().equals("") && coloredX-gg==0)
 						|| (!clueNumbers[coloredY][coloredX-gg].getText().equals("") && !boxes[coloredY][coloredX-gg-1].isEnabled() )  ){
+					// conditional statements find first clue in word (since any word can contain multiple clue numbers)
 					
 					cn_h = Integer.parseInt( clueNumbers[coloredY][coloredX-gg].getText()  );
-					
-					System.out.println( "clue num:"+ cn_h );
-					
+										
 					makeAllCluesWhite();
 					
 					// highlight appropriate clue
@@ -1373,7 +1313,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 	
 	
 	public void makeAllCluesWhite(){
-		//make all other clues white
+		/** Make all clues white (de-highlight them)  **/
 		for( JTextArea cl : cluesAcr ){
 			cl.setBackground(Color.WHITE);
 			cl.setOpaque(true);											

--- a/src/Crossword/DrawCrossword.java
+++ b/src/Crossword/DrawCrossword.java
@@ -1,6 +1,7 @@
 package Crossword;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.FlowLayout;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -66,6 +67,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 	Dimension screenSize;
 	double width;
 	double height;
+	JPanel flow;
 	
 	// Define color highlighting current word
 	Color HIGHLIGHT_COLOUR = new Color(20,100,20,100) ;
@@ -98,6 +100,8 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		frame.setBackground(new Color(255, 255, 255, 255));
 
 		keys = new ArrayList<KeyEvent>();
+		
+		flow = new JPanel(new FlowLayout());
 
 		cluesDwn = new ArrayList<JLabel>();
 		cluesAcr = new ArrayList<JLabel>();
@@ -117,8 +121,8 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		height = screenSize.getHeight();
 		
 		font = new Font("Century Gothic", Font.PLAIN, squareSize / 5 * 3);
-		font2 = new Font("Century Gothic", Font.PLAIN, 24);
-		font3 = new Font("Century Gothic", Font.PLAIN, 15);
+		font2 = new Font("Century Gothic", Font.PLAIN, 24);  //across and down headers
+		font3 = new Font("Century Gothic", Font.PLAIN, 16);  // clues
 		font4 = new Font("Century Gothic", Font.PLAIN, 11);
 		sol = new DrawSolution(grid, x, y, squareSize, "Crossword", this);
 		rand = new Random();
@@ -284,18 +288,24 @@ public class DrawCrossword extends JComponent implements ActionListener {
 
 		for (JLabel j : cluesAcr) {
 			c.weightx = 1.0;
-			c.weighty = 1.0;
+			c.weighty = 0.3;
 			c.gridx = 0;
 			clue.add(j, c);
 		}
 
 		for (JLabel k : cluesDwn) {
 			c.weightx = 1.0;
-			c.weighty = 1.0;
+			c.weighty = 0.3;
 			c.gridx = 0;
 			clue.add(k, c);
 		}
 
+		
+		flow.add(clue);
+		flow.setBorder(null);
+		flow.setBackground(clear);
+		
+		
 		/**
 		 * This is the layout of the GridBagLayout panel main which holds all
 		 * the crossword components. There are two components inside it: A
@@ -303,18 +313,29 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		 */
 		main = new JPanel(new GridBagLayout());
 		main.setBackground(clear);
+		
+
+		
 
 		c.weighty = 1.0;
 		c.weightx = 1.0;
 		c.gridx = 0;
 		c.gridy = 0;
 		main.add(layer, c);
-
+		
 		c.weighty = 1.0;
 		c.weightx = 1.0;
 		c.gridx = 1;
 		c.gridy = 0;
-		main.add(clue, c);
+		c.anchor = GridBagConstraints.FIRST_LINE_START;
+		main.add(flow, c);
+		
+
+//		c.weighty = 1.0;
+//		c.weightx = 1.0;
+//		c.gridx = 1;
+//		c.gridy = 0;
+//		main.add(clue, c);
 
 		/**
 		 * This is the largest area of the GUI which holds the crossword and

--- a/src/Crossword/DrawCrossword.java
+++ b/src/Crossword/DrawCrossword.java
@@ -2,6 +2,7 @@ package Crossword;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
+//import java.awt.MigLayout;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -105,7 +106,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 
 		keys = new ArrayList<KeyEvent>();
 		
-		flow = new JPanel(new FlowLayout());
+		flow = new JPanel(new FlowLayout(FlowLayout.LEFT , 200, 0));
 		//flow2 = new JPanel(new FlowLayout());
 
 		
@@ -228,24 +229,32 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		layer.setPreferredSize(new Dimension(squareSize * (x), squareSize * (y)));
 		layer.setMinimumSize(new Dimension(squareSize * (x - 1), squareSize * (x - 1)));
 
+
 		/**
 		 * This is the GridBagLayout clue which holds all the clue components:
 		 * The numbers and clues in a JTextArea and the hints in a JLabel
 		 */
+		
+		
+		//clue = new JPanel(new FlowLayout(FlowLayout.LEFT , 0, 5));
+		//clue = new JPanel(new FlowLayout());
 		clue = new JPanel(new GridBagLayout());
+		
+		
 		clue.setMinimumSize(new Dimension(squareSize * (x - 1), squareSize * (x - 1)));
 		c = new GridBagConstraints();
 		c.fill = GridBagConstraints.BOTH;
 		clue.setBackground(clear);
-		clue.setAlignmentY(0);
+		//clue.setAlignmentY(0);
+		clue.setAlignmentX(0);
 		//clue.setBounds(200, 200, 200, 200);
 		
-		clue2 = new JPanel(new GridBagLayout());
+		clue2 = new JPanel(new GridBagLayout()     );
 		clue2.setMinimumSize(new Dimension(squareSize * (x - 1), squareSize * (x - 1)));
 		c2 = new GridBagConstraints();
 		c2.fill = GridBagConstraints.BOTH;
 		clue2.setBackground(clear);
-		clue2.setAlignmentY(0);
+		//clue2.setAlignmentY(0);
 		//clue2.setBounds(200, 200, 200, 200);
 		
 		
@@ -333,7 +342,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		for (JTextArea k : cluesDwn) {
 			c2.weightx = 1.0;
 			c2.weighty = 1;
-			c2.gridx = 20;
+			c2.gridx = 0;
 			clue2.add(k, c);
 		}
 
@@ -343,6 +352,12 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		flow.setBackground(clear);
 		
 		flow.add(clue2);
+		
+		flow.setBorder( BorderFactory.createEmptyBorder(0, -200, 0, 0) ); 
+		// THE FLOWLAYOUT I HAVE USED PUTS HAS X AND Y SPACINGS DEFINED. THIS ALSO INCLUDES A SPACE BEFORE THE FIRST COMPONENT
+		// WHICH IS NOT WHAT WE WANT, SO THIS IS TO REMOVE THAT. THE -VE NUMBER HAS TO MATCH THAT ABOVE IN FLOWLAYOUT
+		
+		
 		
 //		flow2.add(clue2);
 //		flow2.setBorder(null);
@@ -354,6 +369,7 @@ public class DrawCrossword extends JComponent implements ActionListener {
 		 * the crossword components. There are two components inside it: A
 		 * JLayeredPane and a GridBagLayout
 		 */
+		
 		main = new JPanel(new GridBagLayout());
 		main.setBackground(clear);
 		

--- a/src/Crossword/DrawCrossword.java
+++ b/src/Crossword/DrawCrossword.java
@@ -592,8 +592,8 @@ public class DrawCrossword extends JComponent implements ActionListener {
 										break;
 									}
 								}	
-								makeAllCluesWhite();
-								colorAppropriateClue();
+								//makeAllCluesWhite();
+								//colorAppropriateClue();
 							}
 							if (e.getKeyCode() == KeyEvent.VK_DOWN) {						
 								makeAllWhite();
@@ -608,8 +608,8 @@ public class DrawCrossword extends JComponent implements ActionListener {
 										break;
 									}						
 								}	
-								makeAllCluesWhite();
-								colorAppropriateClue();
+								//makeAllCluesWhite();
+								//colorAppropriateClue();
 							}
 							if (e.getKeyCode() == KeyEvent.VK_RIGHT) {
 								makeAllWhite();
@@ -624,8 +624,8 @@ public class DrawCrossword extends JComponent implements ActionListener {
 										break;
 									}
 								}		
-								makeAllCluesWhite();
-								colorAppropriateClue();
+								//makeAllCluesWhite();
+								//colorAppropriateClue();
 							}
 							if (e.getKeyCode() == KeyEvent.VK_LEFT) {
 								makeAllWhite();
@@ -640,8 +640,8 @@ public class DrawCrossword extends JComponent implements ActionListener {
 										break;
 									}
 								}	
-								makeAllCluesWhite();
-								colorAppropriateClue();
+								//makeAllCluesWhite();
+								//colorAppropriateClue();
 							}
 							
 							
@@ -719,8 +719,8 @@ public class DrawCrossword extends JComponent implements ActionListener {
 								}
 									
 								
-								makeAllCluesWhite();
-								colorAppropriateClue();
+								//makeAllCluesWhite();
+								//colorAppropriateClue();
 								
 							}
 							

--- a/src/Crossword/ReadWords.java
+++ b/src/Crossword/ReadWords.java
@@ -37,7 +37,7 @@ public class ReadWords {
 					//noDefinitions++;
 				}		
 				definitions.add(definition);
-				Word wordObj = new Word(word, definition);		
+				Word wordObj = new Word(word.trim(), definition.trim());		
 				//Word wordObj = new Word(word, definitions, noDefinitions);	
 				words.add(wordObj);				
 			}catch(NullPointerException e){


### PR DESCRIPTION
Still in the process of playing around with layout of crossword but it's starting to look nice and I think it is more usable. I didn't want to merge to master til you had looked at it / maybe you think I should try and merge this to your Zoom branch first just to test how compatible they are?

What's new:
Implemented your FlowLayout idea and changed all the JLabels to JTextAreas so we could do text wrapping. Split across and down clues into separate panels so they're side by side. (Still need to try and fix their vertical alignment but it looks better than before anyway).

Also I finished implementing clue highlighting when words in crossword are selected - it should be now that there is always one word and one clue highlighted in green. Can change this by clicking on grid, pushing any text or arrow key, or hovering your mouse over the actual clue. 

Let me know if this is working on your computer yet? I changed a lot of the layout parameters so hopefully this issue disappears :P
